### PR TITLE
conduit: Fix compilation error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,8 +9,8 @@ mod download;
 mod heffalump_hh_types;
 
 const CREATOR: [c_uchar; 4] = [b'H', b'E', b'F', b'f'];
-const AUTHOR_DB: &[u8] = include_bytes!("..\\include\\HeffalumpAuthorDB.pdb");
-const CONTENT_DB: &[u8] = include_bytes!("..\\include\\HeffalumpContentDB.pdb");
+const AUTHOR_DB: &[u8] = include_bytes!("../include/HeffalumpAuthorDB.pdb");
+const CONTENT_DB: &[u8] = include_bytes!("../include/HeffalumpContentDB.pdb");
 const MASTADON_INST: &'static str = env!("HEFFALUMP_MASTADON_INST");
 const MASTADON_ACCESS: &'static str = env!("HEFFALUMP_ACCESS_TOKEN");
 


### PR DESCRIPTION
Building the conduit on Linux systems causes an invalid path error.

Fix the issue using the correct path separator.

Note: The patch can be tested using the docker container at [1].

[1] https://github.com/fvincenzo/linux-rust-debian