### PR TITLE
add retries for 429 responses

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heffalump_conduit_installer"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 resolver = "2"
 

--- a/conduit/Cargo.toml
+++ b/conduit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heffalump_conduit"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -10,6 +10,7 @@ byteorder = "1.4.3"
 encoding = "0.2.33"
 hotsync_conduit_rs = { git = "https://github.com/knickish/hotsync_conduit_rs", tag = "v0.4.0"}
 html2text = "0.6.0"
+http = "0.2.11"
 log = "0.4.20"
 megalodon = "0.10.0"
 open = "5.0.0"


### PR DESCRIPTION
Noticed I was hitting `TOO_MANY_REQUESTS` occasionally, added a sleep + retry loop for all the download calls to ameliorate